### PR TITLE
Added recurseDepth option

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,10 +42,14 @@ const importDir = (directory = '.', options = {}) => {
 
             if (fs.statSync(abs).isDirectory()) {
                 if (options.recurse && base != 'node_modules') {
-                    if (options.recurseDepth && options.recurseDepth > options.currentDepth) {
-                        const currentDepth = options.currentDepth ? options.currentDepth+1 : 1;
+                    if (options.recurseDepth) {
+                        options.currentDepth = options.currentDepth ? options.currentDepth : 0;
 
-                        map[base] = importDir(abs, Object.assign(options, { currentDepth }));
+                        if (options.recurseDepth > options.currentDepth) {
+                            const currentDepth = options.currentDepth ? options.currentDepth+1 : 1;
+
+                            map[base] = importDir(abs, Object.assign(options, { currentDepth }));
+                        }
                     }
                     else map[base] = importDir(abs, options);
                 }

--- a/index.js
+++ b/index.js
@@ -42,7 +42,12 @@ const importDir = (directory = '.', options = {}) => {
 
             if (fs.statSync(abs).isDirectory()) {
                 if (options.recurse && base != 'node_modules') {
-                    map[base] = importDir(abs, options);
+                    if (options.recurseDepth && options.recurseDepth > options.currentDepth) {
+                        const currentDepth = options.currentDepth ? options.currentDepth+1 : 1;
+
+                        map[base] = importDir(abs, Object.assign(options, { currentDepth }));
+                    }
+                    else map[base] = importDir(abs, options);
                 }
             }
             else {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@yimura/import-dir",
     "description": "Helper to import() directories.",
-    "version": "0.1.7",
+    "version": "0.1.9",
     "author": "yimura <andreas.maerten@scarlet.be>",
     "license": "MIT",
     "type": "module",


### PR DESCRIPTION
The recurseDepth option requires the recurse key to be also set to true in the options of import-dir.

recurseDepth expects a number, this number being the depth of subdirectories it should go into.